### PR TITLE
Add link to jsbin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Simple EventEmitter for your FE(mb BE)
 
+<a class="jsbin-embed" href="http://jsbin.com/xezuvowozo/embed?html,js,output">JS Bin on jsbin.com</a><script src="http://static.jsbin.com/js/embed.min.js?3.35.5"></script>
+
 ## How to install
 ```bower install is-emitter```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Simple EventEmitter for your FE(mb BE)
 
-<a class="jsbin-embed" href="http://jsbin.com/xezuvowozo/embed?html,js,output">JS Bin on jsbin.com</a><script src="http://static.jsbin.com/js/embed.min.js?3.35.5"></script>
-
 ## How to install
 ```bower install is-emitter```
 
@@ -242,5 +240,7 @@ Method allows to set max listeners count
 })(angular, EventEmitter);
 
 ```
+
+Use [jsbin](http://jsbin.com/xezuvowozo/edit?html,js,output) to see the example of using EventEmitter with angular routes  
 
 ## DOCS IN PROGRESS))


### PR DESCRIPTION
If you want you can change my example. But it's quite comfortable to have an ability to test your EventEmitter right now. That's why I thinks jsbin is a good way
